### PR TITLE
[static] Edit static `serve()` middleware code snippet examples

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -245,10 +245,12 @@ app.use(router.routes());
 import {serve, send} from '@zipadee/static';
 
 // Serve directory
-app.use(serve({
-  root: './public',
-  index: 'index.html'
-}));
+app.use(
+  serve('./public', {
+    root: './public',
+    index: 'index.html',
+  }),
+);
 
 // Send individual file
 app.use(async (req, res) => {

--- a/packages/static/README.md
+++ b/packages/static/README.md
@@ -19,7 +19,7 @@ import {send, serve} from '@zipadee/static';
 const app = new App();
 
 // Serves all files in the directory {cwd}/files/
-app.use(serve({root: 'files'}));
+app.use(serve('files', {root: 'files'}));
 
 app.use(async (req, res, next) => {
   if (req.path === '/hello') {


### PR DESCRIPTION
## Changes
- Update static `serve()` middleware code snippet examples

## Motivation
Was running locally using `serve()` and was getting this error when following code snippet in README doc

``` bash
node:path:1224
      validateString(path, `paths[${i}]`);
      ^

TypeError [ERR_INVALID_ARG_TYPE]: The "paths[0]" argument must be of type string. Received an instance of Object
```

Turns out I wasn't passing `root` (string) arg as expected

Would it be simpler to remove `root` (string) param and just grab root from `opts` (object)? Have it be the same as `javascript` package `serve()` [here](https://github.com/justinfagnani/zipadee/blob/main/packages/javascript/src/lib/serve.ts#L71)?  